### PR TITLE
Make mpich default backend for unidist-mpi

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,9 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-mpi:
-- mpich
-mpich:
-- '4'
-openmpi:
-- '4'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
 mpi:
   - mpich    # [not win]
   - msmpi    # [win]
+
+build:
+  - 100      # [mpi == "mpich"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "unidist" %}
 {% set version = "0.4.1" %}
+{% set build = build or 3 %}
 
 package:
   name: {{ name }}-packages
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 2
+  number: {{ build }}
 
 # the outputs map the unidist options on PyPI (see upstream definition
 # https://github.com/modin-project/unidist/blob/0.2.0/setup.py#L6-L11)
@@ -103,7 +104,7 @@ outputs:
         - {{ pin_subpackage('unidist', exact=True) }}
         - mpi4py >=3.0.3
         # this variable is defined in conda_build_config.yaml
-        - {{ mpi }}
+        - {{ mpi }}  # [build == 100]
         - msgpack-python >=1.0.0
     test:
       # Currently we do not run actual tests for mpi backend because

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
   sha256: f47f09d69327b2e03f2180ac142a76e45fdf12694fe316f51612e38075e7323f
 
 build:
-  noarch: python
   number: {{ build }}
 
 # the outputs map the unidist options on PyPI (see upstream definition


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
